### PR TITLE
Add BIP100 string to getblocktemplate

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1630,8 +1630,12 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
+bool fForceInitialBlockDownload = false;
 bool IsInitialBlockDownload()
 {
+    if (fForceInitialBlockDownload)
+        return false;
+
     const CChainParams& chainParams = Params();
     LOCK(cs_main);
     if (fImporting || fReindex)

--- a/src/main.h
+++ b/src/main.h
@@ -202,6 +202,7 @@ void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */
 int PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader, int64_t nPowTargetSpacing);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
+extern bool fForceInitialBlockDownload;
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
 std::string GetWarnings(std::string strFor);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -57,7 +57,7 @@ void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, 
 // BIP100 string:
 // - Adds our block size vote (B) if configured.
 // - Adds Excessive Block (EB) string. This announces how big blocks we currently accept.
-static std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
+std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
     uint64_t blockVote = Opt().MaxBlockSizeVote();
 
     std::stringstream ss;

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,5 +31,5 @@ CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
-
+std::vector<unsigned char> BIP100Str(uint64_t hardlimit);
 #endif // BITCOIN_MINER_H

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -553,12 +553,14 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         int index_in_template = i - 1;
         entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
         entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
-
         transactions.push_back(entry);
     }
 
+    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
+    CScript flags = CScript() << BIP100Str(nMaxBlockSize);
+    flags +=  COINBASE_FLAGS;
     UniValue aux(UniValue::VOBJ);
-    aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
+    aux.push_back(Pair("flags", HexStr(flags.begin(), flags.end())));
 
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
@@ -570,7 +572,6 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         aMutable.push_back("prevblock");
     }
 
-    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("capabilities", aCaps));
     result.push_back(Pair("version", pblock->nVersion));


### PR DESCRIPTION
This adds BIP100 votes to blocks generated by miner software that
uses the rpc call getblocktemplate.