### PR TITLE
move IsConfiguredDeployment

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,7 +347,6 @@ libbitcoin_common_a_SOURCES = \
   base58.cpp \
   cashaddr.cpp \
   cashaddrenc.cpp \
-  chain.cpp \
   chainparams.cpp \
   coins.cpp \
   compressor.cpp \
@@ -363,7 +362,6 @@ libbitcoin_common_a_SOURCES = \
   scheduler.cpp \
   script/sign.cpp \
   script/standard.cpp \
-  versionbits.cpp \
   utxocommit.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -411,28 +411,3 @@ void SelectParams(const std::string& network)
     SelectBaseParams(network);
     pCurrentParams = &Params(network);
 }
-
-// bip135 begin
-/**
- * Return true if a deployment is considered to be configured for the network.
- * Deployments with a zero-length name, or a windowsize or threshold equal to
- * zero are not considered to be configured, and will be reported as 'unknown'
- * if signals are detected for them.
- * Unconfigured deployments can be ignored to save processing time, e.g.
- * in ComputeBlockVersion() when computing the default block version to emit.
- */
-bool IsConfiguredDeployment(const Consensus::Params &consensusParams, const int bit)
-{
-    const Consensus::ForkDeployment *vdeployments = consensusParams.vDeployments;
-    const struct ForkDeploymentInfo &vbinfo = VersionBitsDeploymentInfo[bit];
-
-    if (strlen(vbinfo.name) == 0)
-        return false;
-
-    if (vdeployments[bit].windowsize == 0 || vdeployments[bit].threshold == 0)
-    {
-        return false;
-    }
-    return true;
-}
-// bip135 end

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -127,6 +127,18 @@ const struct ForkDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION
     }};
 // bip135 end
 
+bool IsConfiguredDeployment(const Consensus::Params &consensusParams, const int bit)
+{
+    if (std::string(VersionBitsDeploymentInfo[bit].name).empty()) {
+        return false;
+    }
+
+    const Consensus::ForkDeployment& d = consensusParams.vDeployments[bit];
+    if (d.windowsize == 0 || d.threshold == 0) {
+        return false;
+    }
+    return true;
+}
 
 // bip135 begin
 bool AbstractThresholdConditionChecker::backAtDefined(ThresholdConditionCache &cache, const CBlockIndex *pindex) const

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -34,6 +34,12 @@ enum ThresholdState
 // will either be NULL or a block with (height + 1) % Period() == 0.
 typedef std::map<const CBlockIndex*, ThresholdState> ThresholdConditionCache;
 
+/**
+ * Returns true if a deployment is configured on given network.
+ * This requires at minimum that the bit has a name, threshold and window size.
+ */
+bool IsConfiguredDeployment(const Consensus::Params &consensusParams, const int bit);
+
 struct ForkDeploymentInfo
 {
     /** Deployment name */
@@ -41,8 +47,6 @@ struct ForkDeploymentInfo
     /** Whether GBT clients can safely ignore this rule in simplified usage */
     bool gbt_force;
 };
-
-extern const struct ForkDeploymentInfo VersionBitsDeploymentInfo[];
 
 /**
  * Abstract class that implements BIP135-style threshold logic, and caches results.


### PR DESCRIPTION
Move IsConfiguredDeployment

This removes the need for modifying the Makefile and exposing VersionBitsDeploymentInfo as a global variable.

The function is also slightly shortened.


